### PR TITLE
Update JdbcExample.java

### DIFF
--- a/java/JdbcExample.java
+++ b/java/JdbcExample.java
@@ -45,7 +45,8 @@ public class JdbcExample {
       sql = "USE adventureworks;";
       ResultSet rs;
       //rs = stmt.executeQuery(sql); only works with old versions
-      rs = stmt.execute(sql);
+      //rs = stmt.execute(sql); 'execute' may or may not be a valid command depending on version
+      stmt.executeUpdate(sql);
       sql = "SELECT EmployeeId, LoginID from employee";
       rs = stmt.executeQuery(sql);
 


### PR DESCRIPTION
Uses command stmt.executeUpdate(sql); instead of stmt.execute(sql); as execute is not a valid command for certain versions.